### PR TITLE
Use correct type for FILEBENCH_AVD entries calculation

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -478,7 +478,7 @@ preallocated_entries(int obj_type)
 		break;
 	case FILEBENCH_AVD:
 		entries = sizeof(filebench_shm->shm_avd_ptrs)
-						/ sizeof(avd_t);
+						/ sizeof(struct avd);
 		break;
 	case FILEBENCH_RANDDIST:
 		entries = sizeof(filebench_shm->shm_randdist)


### PR DESCRIPTION
filebench_shm->shm_avd_ptrs is an array of struct avd elements, so
the correct type to use when working out how many of them we have
is 'struct avd', not 'avd_t'