### PR TITLE
Replace sigignore with plain signal(sig ,SIG_IGN)

### DIFF
--- a/README_COND_COMP
+++ b/README_COND_COMP
@@ -174,11 +174,6 @@ HAVE_SHM_SHARE_MMU
 	SHM_SHARE_MMU flag for shmat() is defined on Solaris.
 	Use it, if possible.
 
-HAVE_SIGIGNORE
-
-	On FreeBSD sigignore is not available, so we emulate
-	it via sigaction()
-
 HAVE_SIGSEND
 
 	Solaris has sigsend() syscall that allows to

--- a/configure.ac
+++ b/configure.ac
@@ -105,10 +105,6 @@ AC_CHECK_FUNCS([cftime])
 AC_CHECK_FUNC(
 	[_lwp_self],
         [ AC_DEFINE(HAVE_LWPS, 1, [ Define if you have lwps ])])
-# Check for sigignore() function: not available on FreeBSD
-AC_CHECK_FUNC(
-	[sigignore],
-        [ AC_DEFINE(HAVE_SIGIGNORE, 1, [ Define if you have sigignore ])])
 
 ####
 #### Check for more sophisticated functions

--- a/filebench.h
+++ b/filebench.h
@@ -157,16 +157,6 @@ void filebench_plugin_funcvecinit(void);
 #define	FILEBENCH_RANDMAX FILEBENCH_RANDMAX32
 #endif
 
-#ifndef HAVE_SIGIGNORE
-/* No sigignore on FreeBSD */
-static inline int sigignore(int sig) {
-        struct sigaction sa;
-        bzero(&sa, sizeof(sa));
-        sa.sa_handler = SIG_IGN;
-        return (sigaction(sig, &sa, NULL));
-}
-#endif
-
 #define	KB (1024LL)
 #define	MB (KB * KB)
 #define	GB (KB * MB)

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1575,7 +1575,7 @@ cvars_mode(struct fbparams *fbparams)
 static void
 parser_abort(int arg)
 {
-	(void) sigignore(SIGINT);
+	signal(SIGINT, SIG_IGN);
 	filebench_log(LOG_INFO, "Aborting...");
 	filebench_shutdown(1);
 }

--- a/procflow.c
+++ b/procflow.c
@@ -106,7 +106,7 @@ procflow_createproc(procflow_t *procflow)
 		char syscmd[1024];
 #endif
 
-		(void) sigignore(SIGINT);
+		signal(SIGINT, SIG_IGN);
 		filebench_log(LOG_DEBUG_SCRIPT,
 		    "Starting %s-%d", procflow->pf_name,
 		    procflow->pf_instance);


### PR DESCRIPTION
The sigignore function is considered deprecated on some platforms,
giving warnings during the build:

  procflow.c:109:3: warning: ‘sigignore’ is deprecated: Use the signal
  function instead [-Wdeprecated-declarations]

  parser_gram.y:1578:2: warning: ‘sigignore’ is deprecated: Use the signal
  function instead [-Wdeprecated-declarations]

Replace the use of sigignore with the equivalent signal(XX, SIG_IGN);
the signal function is already used in the code without any configure
check.

Remove the configure check for sigignore and the fallback to sigaction.